### PR TITLE
Put custom css property defaults in proper place

### DIFF
--- a/iron-drag-drop.html
+++ b/iron-drag-drop.html
@@ -61,8 +61,6 @@ Custom property | Description | Default
       :host {
         display: block;
         box-sizing: border-box;
-        --iron-drag-drop-border: 2px solid transparent;
-        --iron-drag-drop-border-dragging: 2px solid #B9B9B9;
       }
 
       .drop-zone {
@@ -71,11 +69,11 @@ Custom property | Description | Default
         width: 100%;
         z-index: 0;
         transition: border-color 0.25s;
-        border: var(--iron-drag-drop-border);
+        border: var(--iron-drag-drop-border, 2px solid transparent);
       }
 
       .drop-zone.dragging {
-        border: var(--iron-drag-drop-border-dragging);
+        border: var(--iron-drag-drop-border-dragging, 2px solid #B9B9B9);
       }
 
       /* Use this to prevent the dragleave


### PR DESCRIPTION
Defining these properties inside the :host rule means that they must be
overridden by specifically specifying the element (e.g. by using an id or
class given to the element by the consumer, or by using the element's
name). Using a broader default selector for all iron-drag-drop
instances (like :root or even selecting a parent element) is impossible.

By specifying the default in the call to var(), the default is much
more easily overridden.

See

```
<html>
<head>
  <style is='custom-style'>
    .stuff { /* Possible by providing a default in the var() call */
       --iron-drag-drop-border: 3px dashed yellow;
        --iron-drag-drop-border-dragging: 3px dashed blue;
      }
    .foo { /* Selecting the component directly is necessary  */
       --iron-drag-drop-border: 3px dashed yellow;
        --iron-drag-drop-border-dragging: 3px dashed blue;
      }
    }
  </style>
  <link rel="stylesheet" href="/styles.css">
  <link rel="import" href="/bower_components/iron-drag-drop/iron-drag-drop.html">
</head>
<body>
  <div class="stuff">
    <iron-drag-drop class="foo"><p>Hey!</p></iron-drag-drop>
  </div>
</body>
</html>
```
